### PR TITLE
Missing JS-files fix

### DIFF
--- a/src/Aimeos/Shop/Controller/AdminController.php
+++ b/src/Aimeos/Shop/Controller/AdminController.php
@@ -122,7 +122,7 @@ class AdminController extends Controller
 
 		foreach( $jsFiles as $file )
 		{
-			if( ( $content = file_get_contents( $file ) ) !== false ) {
+			if( ( file_exists($file) ) && ( $content = file_get_contents( $file ) ) !== false ) {
 				$contents .= $content;
 			}
 		}


### PR DESCRIPTION
When using extensions without JS client files, error was thrown.