### PR TITLE
Update README to match docs - AuthServiceProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ public function boot(GateContract $gate)
 	// Keep the lines before
 
 	$gate->define('admin', function($user, $roles) {
-		return app( '\Aimeos\Shop\Base\Support' )->checkGroup( $user->id, $roles );
+		return app( '\Aimeos\Shop\Base\Support' )->checkGroup( $user->id, 'admin' );
 	});
 }
 ```


### PR DESCRIPTION
The README file notes to use $roles, but this causes an error (confirmed in Laravel 5.2).
Switching to 'admin' as noted in the docs does not cause an error.