### PR TITLE
Update README.md - cache table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ If you don't get redirected to the admin interface (that depends on the authenti
 code you've created according to the Laravel documentation), point your browser to the
 `/admin` URL again.
 
+it's necessary to use a table to save the cache. You can run `php artisan cache:table` to generate the migration file and then `php artisan migrate` to create the table.
+
 To see your uploaded images, you have to adapt your `.env` file and set the `APP_URL`:
 
 ```APP_URL=http://127.0.0.1:8000```


### PR DESCRIPTION
README.md has been updated to specify that it is necessary to create the cache table for the admin environment to work correctly.

In case of not doing so, the following error appears in login process:

`
Illuminate\Database\QueryException thrown with message "SQLSTATE[42S02]: Base table or view not found: 1146 Table 'YOUR_DATABASE.cache' doesn't exist (SQL: select * from 'cache' where 'key' = YOUR_DATABASE_cachetest@example.com|170.10.10.1 limit 1)"
`