### PR TITLE
Update shop.php

### DIFF
--- a/src/config/shop.php
+++ b/src/config/shop.php
@@ -69,7 +69,7 @@ return [
 			],
 			'common' => [
 				'template' => [
-					// 'baseurl' => public_path( 'packages/aimeos/shop/themes/elegance' ),
+					// 'baseurl' => 'packages/aimeos/shop/themes/elegance',
 				],
 			],
 		],


### PR DESCRIPTION
The public_path function returns the fully qualified path to the public directory, so the path that is returned can't be resolved in base.blade.php.

Asset function, in base.blade.php, generates the correct full URL, so just pass it the string with the relative path value.