### PR TITLE
Feat: add multi guards support

### DIFF
--- a/src/Aimeos/Shop/Base/Context.php
+++ b/src/Aimeos/Shop/Base/Context.php
@@ -241,20 +241,14 @@ class Context
 	 */
 	protected function addUser( \Aimeos\MShop\Context\Item\Iface $context ) : \Aimeos\MShop\Context\Item\Iface
 	{
-		$guard = data_get(
-			$context->getConfig()->get('guards'),
-			collect($context->getConfig()->get('routes'))
-				->where('prefix', Route::getCurrentRoute()->getPrefix())
-				->keys()
-				->first(),
-			Auth::getDefaultDriver()
-		);
+		$key = collect( config( 'routes' ) )->where( 'prefix', Route::getCurrentRoute()->getPrefix() )->keys()->first();
+		$guard = data_get( config( 'guards' ), $key, Auth::getDefaultDriver() );
 
-		if( ( $userid = Auth::guard($guard)->id() ) !== null ) {
+		if( ( $userid = Auth::guard( $guard )->id() ) !== null ) {
 			$context->setUserId( $userid );
 		}
 
-		if( ( $user = Auth::guard($guard)->user() ) !== null ) {
+		if( ( $user = Auth::guard( $guard )->user() ) !== null ) {
 			$context->setEditor( $user->name );
 		} else {
 			$context->setEditor( \Request::ip() );

--- a/src/Aimeos/Shop/Base/Context.php
+++ b/src/Aimeos/Shop/Base/Context.php
@@ -11,6 +11,7 @@ namespace Aimeos\Shop\Base;
 
 
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
 
 
 /**
@@ -240,11 +241,20 @@ class Context
 	 */
 	protected function addUser( \Aimeos\MShop\Context\Item\Iface $context ) : \Aimeos\MShop\Context\Item\Iface
 	{
-		if( ( $userid = Auth::id() ) !== null ) {
+		$guard = data_get(
+			$context->getConfig()->get('guards'),
+			collect($context->getConfig()->get('routes'))
+				->where('prefix', Route::getCurrentRoute()->getPrefix())
+				->keys()
+				->first(),
+			Auth::getDefaultDriver()
+		);
+
+		if( ( $userid = Auth::guard($guard)->id() ) !== null ) {
 			$context->setUserId( $userid );
 		}
 
-		if( ( $user = Auth::user() ) !== null ) {
+		if( ( $user = Auth::guard($guard)->user() ) !== null ) {
 			$context->setEditor( $user->name );
 		} else {
 			$context->setEditor( \Request::ip() );

--- a/src/Aimeos/Shop/Base/Context.php
+++ b/src/Aimeos/Shop/Base/Context.php
@@ -241,7 +241,7 @@ class Context
 	 */
 	protected function addUser( \Aimeos\MShop\Context\Item\Iface $context ) : \Aimeos\MShop\Context\Item\Iface
 	{
-		$key = collect( config( 'routes' ) )->where( 'prefix', Route::getCurrentRoute()->getPrefix() )->keys()->first();
+		$key = collect( config( 'routes' ) )->where( 'prefix', optional(Route::getCurrentRoute())->getPrefix() )->keys()->first();
 		$guard = data_get( config( 'guards' ), $key, Auth::getDefaultDriver() );
 
 		if( ( $userid = Auth::guard( $guard )->id() ) !== null ) {

--- a/src/Aimeos/Shop/Base/Context.php
+++ b/src/Aimeos/Shop/Base/Context.php
@@ -241,8 +241,8 @@ class Context
 	 */
 	protected function addUser( \Aimeos\MShop\Context\Item\Iface $context ) : \Aimeos\MShop\Context\Item\Iface
 	{
-		$key = collect( config( 'routes' ) )->where( 'prefix', optional(Route::getCurrentRoute())->getPrefix() )->keys()->first();
-		$guard = data_get( config( 'guards' ), $key, Auth::getDefaultDriver() );
+		$key = collect( config( 'shop.routes' ) )->where( 'prefix', optional(Route::getCurrentRoute())->getPrefix() )->keys()->first();
+		$guard = data_get( config( 'shop.guards' ), $key, Auth::getDefaultDriver() );
 
 		if( ( $userid = Auth::guard( $guard )->id() ) !== null ) {
 			$context->setUserId( $userid );


### PR DESCRIPTION
By default it uses the default guard set in config/auth.php, but the user can override this behaviour.

He simply has to add the following key/value pair in the aimeos shop config file with the aimeos app parts he wants to override with the custom guard.

```php
 'guards' => [
	'jsonadm' => 'custom-guard1',
	'jsonapi' => 'custom-guard2',
 ],
```