### PR TITLE
Merge custom site configuration on admin pages

### DIFF
--- a/src/Aimeos/Shop/Controller/JqadmController.php
+++ b/src/Aimeos/Shop/Controller/JqadmController.php
@@ -257,6 +257,17 @@ class JqadmController extends AdminController
 		$context = app( 'aimeos.context' )->get( false, 'backend' );
 		$context->setI18n( app( 'aimeos.i18n' )->get( array( $lang, 'en' ) ) );
 		$context->setLocale( app( 'aimeos.locale' )->getBackend( $context, $site ) );
+		
+		$siteManager = \Aimeos\MShop::create( $context, 'locale/site');
+
+		$filter = $siteManager->filter();
+		$filter->add([ 'locale.site.code' => $site ]);
+    
+		$siteItem = $siteManager->search( $filter->slice( 0 ) );
+		$siteConfig = $siteItem->getConfig()->toArray();
+		$siteConfig = array_pop( $siteConfig );
+
+		$context->config()->apply( $siteConfig );
 
 		$view = app( 'aimeos.view' )->create( $context, $paths, $lang );
 


### PR DESCRIPTION
Merge custom site configuration on admin pagesFollowing on from this issue:

https://github.com/aimeos/aimeos-core/issues/296

I have merged the custom site entries on the context of the admin pages.