### PR TITLE
fix documentation publish command (#284)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ In the last step you must now execute these artisan commands to get a working
 or updated Aimeos installation:
 
 ```
-php artisan vendor:publish --all
+php artisan vendor:publish --provider="Aimeos\Shop\ShopServiceProvider"
 php artisan migrate
 php artisan aimeos:setup --option=setup/default/demo:1
 ```


### PR DESCRIPTION
regarding #284 the publish command in the [installation section of the docs](https://github.com/aimeos/aimeos-laravel#installation) would publish all migrations, public assets, configs and views.

Depending the amount of packages this could lead to a tremendous amount of published files that most likely would not be necessary.

Changing `php artisan vendor:publish --all` to `php artisan vendor:publish --provider="Aimeos\Shop\ShopServiceProvider"` publishes all files needed for the aimeos Laravel package to work.