### PR TITLE
Update JsonapiController.php

### DIFF
--- a/src/Aimeos/Shop/Controller/JsonapiController.php
+++ b/src/Aimeos/Shop/Controller/JsonapiController.php
@@ -108,9 +108,9 @@ class JsonapiController extends Controller
 		$related = Route::input( 'related', Request::get( 'related' ) );
 
 		$aimeos = app( 'aimeos' )->get();
-		$tmplPaths = $aimeos->getTemplatePaths( 'client/jsonapi/templates' );
-
 		$context = app( 'aimeos.context' )->get();
+		$tmplPaths = $aimeos->getTemplatePaths( 'client/jsonapi/templates', $context->locale()->getSiteItem()->getTheme() );
+
 		$langid = $context->locale()->getLanguageId();
 
 		$context->setView( app( 'aimeos.view' )->create( $context, $tmplPaths, $langid ) );


### PR DESCRIPTION
This fix allows to automatically add template files from custom theme. Without it developer should copy JsonapiController, rewrite it and add custom routes for using its own templates.