### PR TITLE
Fix CORS Origin reflection in JsonapiController::optionsAction() (CWE-942)

### DIFF
--- a/src/Controller/JsonapiController.php
+++ b/src/Controller/JsonapiController.php
@@ -88,10 +88,15 @@ class JsonapiController extends Controller
 	 */
 	public function optionsAction( ServerRequestInterface $request )
 	{
-		return $this->createClient()->options( $request, ( new Psr17Factory )->createResponse() )
+		$allowed = config( 'shop.cors.origins', [] );
+		$origin = $request->getHeaderLine( 'origin' );
+		$header = in_array( $origin, $allowed, true ) ? $origin : '';
+
+		$response = $this->createClient()->options( $request, ( new Psr17Factory )->createResponse() )
 			->withHeader( 'access-control-allow-headers', 'authorization,content-type' )
-			->withHeader( 'access-control-allow-methods', 'DELETE, GET, OPTIONS, PATCH, POST, PUT' )
-			->withHeader( 'access-control-allow-origin', $request->getHeaderLine( 'origin' ) );
+			->withHeader( 'access-control-allow-methods', 'DELETE, GET, OPTIONS, PATCH, POST, PUT' );
+
+		return $header ? $response->withHeader( 'access-control-allow-origin', $header ) : $response;
 	}
 
 


### PR DESCRIPTION
## Security Fix — CORS Origin Header Reflection (CWE-942)

### Summary

`JsonapiController::optionsAction()` echoes the raw `Origin` request header verbatim into `Access-Control-Allow-Origin` with no validation. Combined with `Access-Control-Allow-Headers: authorization,content-type`, this lets any attacker-controlled domain pass CORS preflight for all JSON API methods (DELETE, GET, PATCH, POST, PUT).

**Introduced**: commit `1a715db` — "Added headers required for CORS in JSON API OPTIONS response" (Jan 23, 2023)

### Root Cause

```php
// BEFORE — reflects any origin with no allowlist:
->withHeader( 'access-control-allow-origin', $request->getHeaderLine( 'origin' ) );
```

### Fix

Replace verbatim reflection with an allowlist check against `shop.cors.origins`:

```php
$allowed = config( 'shop.cors.origins', [] );
$origin  = $request->getHeaderLine( 'origin' );
$header  = in_array( $origin, $allowed, true ) ? $origin : '';

$response = $this->createClient()->options( $request, ( new Psr17Factory )->createResponse() )
    ->withHeader( 'access-control-allow-headers', 'authorization,content-type' )
    ->withHeader( 'access-control-allow-methods', 'DELETE, GET, OPTIONS, PATCH, POST, PUT' );

return $header ? $response->withHeader( 'access-control-allow-origin', $header ) : $response;
```

No `Access-Control-Allow-Origin` header is emitted when the requesting origin is not in the allowlist. Existing deployments with no SPA frontend are unaffected (empty allowlist = no CORS header = same-origin only, which was the pre-2023 behaviour).

### Impact

- Cross-origin state mutations (PATCH/DELETE) on the JSON API using a victim's Bearer token
- Affected resources: customer profiles, orders, basket, reviews, subscriptions
- Attack requires the victim's Bearer token (e.g. obtained via XSS or token leakage elsewhere)

### Verification

Confirmed on v2026.04.1 (Docker lab, PHP 8.2):

```
curl -si -X OPTIONS "http://localhost/jsonapi/customer" \
  -H "Origin: https://evil.com" \
  -H "Access-Control-Request-Method: PATCH"

HTTP/1.1 200 OK
access-control-allow-origin: https://evil.com   ← reflected verbatim (before fix)
```

After fix: no `access-control-allow-origin` header unless `https://evil.com` is in `shop.cors.origins`.

### Migration

To allow cross-origin access from a known frontend, add to `config/shop.php`:

```php
'cors' => [
    'origins' => [
        'https://your-frontend.example.com',
    ],
],
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)